### PR TITLE
Fixed Add post to start

### DIFF
--- a/src/components/main/create_post/create_post.jsx
+++ b/src/components/main/create_post/create_post.jsx
@@ -30,7 +30,7 @@ class CreatePost extends Component {
     if (title && body) {
       try {
         this.props.addPostBegin();
-        tmp.push({ title, body });
+        tmp.unshift({ title, body });
         this.props.addPostSuccess(tmp);
         this.props.clearPostFields();
         console.log(tmp);


### PR DESCRIPTION
New post elements where being pushed to the end of the array and ended up being rendered at the end of the page.
Now they are being viewed at the top.